### PR TITLE
Add integration tests, X11 dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,11 +3,12 @@ on:
   push:
   pull_request:
 
+env:
+  LIBGDIPLUS_VERSION: '6.0.5'
+
 jobs:
   build:
     runs-on: macOS-10.15
-    env:
-      LIBGDIPLUS_VERSION: '6.0.5'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,6 +22,7 @@ jobs:
           cd runtime.osx.10.10-x64.CoreCompat.System.Drawing
           git clone https://github.com/mono/libgdiplus --depth 1 --single-branch --branch ${LIBGDIPLUS_VERSION}
           brew install libtiff giflib libjpeg glib cairo freetype fontconfig libpng
+
       - name: Build
         run: |
           cd runtime.osx.10.10-x64.CoreCompat.System.Drawing
@@ -40,3 +42,39 @@ jobs:
           name: libgdiplus
           path: |
             ${{ github.workspace }}/bin/
+
+  test:
+    runs-on: macOS-10.15
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: libgdiplus
+          path: |
+            ${{ github.workspace }}/bin/
+
+      - name: Clean dependencies
+        run: |
+          brew remove --force $(brew list)
+
+          echo
+          echo "=========================="
+          echo "Contents of /usr/local/opt"
+          echo "=========================="
+          echo
+
+          ls -l /usr/local/opt/
+
+      - name: Test
+        run: |
+          cd runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests
+
+          dotnet nuget list source
+          dotnet nuget add source ${{ github.workspace }}/bin/ -n ci
+
+          dotnet add package runtime.osx.10.10-x64.CoreCompat.System.Drawing --version ${LIBGDIPLUS_VERSION}.${GITHUB_RUN_NUMBER}
+          DYLD_PRINT_LIBRARIES=1 dotnet run

--- a/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests/UnitTest.cs
+++ b/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests/UnitTest.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using Xunit;
+
+namespace CoreCompat.System.Drawing.Tests
+{
+    public class ImageFormatTests
+    {
+        [Fact]
+        public void WriteImages()
+        {
+            using(var bitmap = new Bitmap(512, 512))
+            {
+                bitmap.Save("test.bmp", ImageFormat.Bmp);
+                bitmap.Save("test.jpg", ImageFormat.Jpeg);
+                bitmap.Save("test.gif", ImageFormat.Gif);
+                bitmap.Save("test.ico", ImageFormat.Icon);
+                bitmap.Save("test.png", ImageFormat.Png);;
+                bitmap.Save("test.tiff", ImageFormat.Tiff);
+                bitmap.Save("test.wmf", ImageFormat.Wmf);
+            }
+        }
+    }
+}

--- a/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests.csproj
+++ b/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests/runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+</Project>

--- a/runtime.osx.10.10-x64.CoreCompat.System.Drawing/build.sh
+++ b/runtime.osx.10.10-x64.CoreCompat.System.Drawing/build.sh
@@ -52,7 +52,7 @@ for f in "$out/lib/"*.dylib; do
 done
 
 echo "---- available dylib files:"
-ls -l "$out/lib/*.dylib"
+ls -l "$out/lib/"*.dylib
 echo "---- available dylib files"
 
 # Build the lighthouse library

--- a/runtime.osx.10.10-x64.CoreCompat.System.Drawing/build.sh
+++ b/runtime.osx.10.10-x64.CoreCompat.System.Drawing/build.sh
@@ -26,9 +26,26 @@ for dylib in $dylibs; do
   cp $dylib "$out/lib/"
 done;
 
-# libcairo has a dependency on libpixman, so include that one, too
-cp /usr/local/opt/pixman/lib/libpixman-1.0.dylib "$out/lib"
-cp /usr/local/lib/libpcre.1.dylib "$out/lib"
+# libcairo has various dependencies, so include those too
+dylibs=`otool -L "$out/lib/libcairo.2.dylib" | grep "/usr/local" | awk -F' ' '{ print $1 }'`
+
+for dylib in $dylibs; do
+  cp $dylib "$out/lib/"
+done;
+
+# libxcb has various dependencies, so include those too
+dylibs=`otool -L "$out/lib/libxcb.1.dylib" | grep "/usr/local" | awk -F' ' '{ print $1 }'`
+
+for dylib in $dylibs; do
+  cp $dylib "$out/lib/"
+done;
+
+# libxcb has various dependencies, so include those too
+dylibs=`otool -L "$out/lib/libglib-2.0.0.dylib" | grep "/usr/local" | awk -F' ' '{ print $1 }'`
+
+for dylib in $dylibs; do
+  cp $dylib "$out/lib/"
+done;
 
 # Patch the dylib dependencies for all .dylib files in the out directory
 for f in "$out/lib/"*.dylib; do

--- a/runtime.osx.10.10-x64.CoreCompat.System.Drawing/runtime.osx.10.10-x64.CoreCompat.System.Drawing.csproj
+++ b/runtime.osx.10.10-x64.CoreCompat.System.Drawing/runtime.osx.10.10-x64.CoreCompat.System.Drawing.csproj
@@ -12,44 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(LibgdiplusDir)libcairo.2.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libfontconfig.1.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libfreetype.6.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libgif.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libglib-2.0.0.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libintl.8.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libjpeg.9.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libpixman-1.0.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libtiff.5.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libpcre.1.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libgdiplus.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="$(LibgdiplusDir)libpng16.16.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
-    <Content Include="libgdiplus-lighthouse.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-    </Content>
+    <Content Include="$(LibgdiplusDir)*.dylib" PackagePath="runtimes/osx-x64/native/"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As a result of https://github.com/Homebrew/homebrew-core/pull/71932, libgdiplus now has a dependency on X11 (via libcairo).