### PR TITLE
Add Azure Pipelines for macOS 10.14 support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,79 @@
+variables:
+  LIBGDIPLUS_VERSION: '6.0.5'
+
+jobs:
+- job: build
+  pool:
+    vmImage: 'macOS-10.14'
+
+  steps:
+  - script: |
+      brew install autoconf automake libtool pkg-config
+    displayName: Install autotools
+
+  - script: |
+      cd runtime.osx.10.10-x64.CoreCompat.System.Drawing
+      git clone https://github.com/mono/libgdiplus --depth 1 --single-branch --branch ${LIBGDIPLUS_VERSION}
+      brew install libtiff giflib libjpeg glib cairo freetype fontconfig libpng
+    displayName: Download sources, install dependencies
+
+  - script: |
+      cd runtime.osx.10.10-x64.CoreCompat.System.Drawing
+
+      # libffi is keg-only
+      export LDFLAGS="-L/usr/local/opt/libffi/lib"
+      export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+
+      ./build.sh
+      mkdir ${BUILD_ARTIFACTSTAGINGDIRECTORY}/libgdiplus
+      dotnet build -c Release /p:Version=${LIBGDIPLUS_VERSION}.${BUILD_BUILDID}
+      dotnet pack -c Release /p:Version=${LIBGDIPLUS_VERSION}.${BUILD_BUILDID} -o ${BUILD_ARTIFACTSTAGINGDIRECTORY}/libgdiplus
+    displayName: Build
+    
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/libgdiplus'
+      artifactName: 'libgdiplus'
+      publishLocation: 'Container'
+    condition: always()
+    displayName: Upload NuGet package
+
+- job: test
+  dependsOn: build
+  pool:
+    vmImage: 'macOS-10.14'
+
+  steps:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: 'libgdiplus'
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 5.0.400
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
+  - script: |
+      brew remove --force $(brew list)
+
+      echo
+      echo "=========================="
+      echo "Contents of /usr/local/opt"
+      echo "=========================="
+      echo
+
+      ls -l /usr/local/opt/
+    displayName: Clean dependencies
+
+  - script: |
+      cd runtime.osx.10.10-x64.CoreCompat.System.Drawing.Tests
+
+      $(Agent.ToolsDirectory)/dotnet/dotnet nuget list source
+      $(Agent.ToolsDirectory)/dotnet/dotnet nuget add source $(System.ArtifactsDirectory)/libgdiplus/ -n ci
+
+      $(Agent.ToolsDirectory)/dotnet/dotnet add package runtime.osx.10.10-x64.CoreCompat.System.Drawing --version ${LIBGDIPLUS_VERSION}.${BUILD_BUILDID}
+      $(Agent.ToolsDirectory)/dotnet/dotnet test
+    displayName: Test
+    

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Install autotools
         run: 
           brew install autoconf automake libtool pkg-config
+
       - name: Download sources, install dependencies
         run: |
           cd runtime.osx.10.10-x64.CoreCompat.System.Drawing
@@ -77,4 +78,4 @@ jobs:
           dotnet nuget add source ${{ github.workspace }}/bin/ -n ci
 
           dotnet add package runtime.osx.10.10-x64.CoreCompat.System.Drawing --version ${LIBGDIPLUS_VERSION}.${GITHUB_RUN_NUMBER}
-          DYLD_PRINT_LIBRARIES=1 dotnet test
+          dotnet test


### PR DESCRIPTION
Building with macOS 10.15 creates compatibility issues with macOS 10.13, so let's build using macOS 10.14 instead.

GitHub doesn't offer macOS 10.14 runners, so we're back to using Azure DevOps for that.

```
dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
  Referenced from: /Users/vagrant/.nuget/packages/runtime.osx.10.10-x64.corecompat.system.drawing/6.0.5.34/runtimes/osx-x64/native/libfontconfig.1.dylib (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libSystem.B.dylib
dyld: Symbol not found: ____chkstk_darwin
  Referenced from: /Users/vagrant/.nuget/packages/runtime.osx.10.10-x64.corecompat.system.drawing/6.0.5.34/runtimes/osx-x64/native/libfontconfig.1.dylib (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libSystem.B.dylib
```